### PR TITLE
Add macOS DMG build scripts for Mixtral 8x7B Ollama web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# mixtral8x7bmacos
+# Mixtral 8x7B macOS DMG
+
+This repository outlines a minimal DMG package for macOS that installs the
+[Ollama](https://ollama.ai) runtime, fetches the Mixtral 8x7B model, and launches a
+simple web interface. When opened, the page automatically sends an unrestricted
+prompt about a cat sitting on a pile of money and displays the model response.
+
+## Contents
+
+- `build_dmg.sh` &ndash; creates `mixtral8x7b.dmg` using `hdiutil`.
+- `install.sh` &ndash; runs from the DMG to install Ollama, pull the model and open the GUI.
+- `webgui/index.html` &ndash; browser client that talks to the local Ollama server.
+
+## Building the DMG
+
+1. Clone this repository on a macOS machine and ensure the build script is
+   executable: `chmod +x build_dmg.sh install.sh` (already set in git but
+   included here for completeness).
+2. Run `./build_dmg.sh` to create the installer image. The script packages
+   `install.sh` and the `webgui` folder and outputs
+   `dist/mixtral8x7b.dmg`.
+3. (Optional) To share the DMG without macOS Gatekeeper warnings, sign and
+   notarize it with your Apple Developer ID using `codesign` and
+   `xcrun notarytool`.
+4. Distribute the resulting `dist/mixtral8x7b.dmg` to end users.
+
+## Installing and Running
+
+1. On another macOS machine, double-click the DMG to mount it. If Gatekeeper
+   warns about an unsigned script, right-click `install.sh` and choose **Open**.
+2. `install.sh` installs Ollama if needed, pulls the Mixtral 8x7B model and
+   starts the Ollama service.
+3. The default browser opens `webgui/index.html`, automatically issuing the
+   example “cat on a pile of money” prompt. You can edit the prompt and send
+   new requests from the page.
+
+This setup avoids additional content restrictions; the model output is entirely
+controlled by your prompts.
+

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_NAME="MixtralWebGUI"
+VOL_NAME="MixtralWebGUI"
+DMG_NAME="mixtral8x7b.dmg"
+
+rm -rf build dist
+mkdir -p "build/$APP_NAME" dist
+
+cp install.sh "build/$APP_NAME/"
+cp -r webgui "build/$APP_NAME/webgui"
+
+hdiutil create "dist/$DMG_NAME" -volname "$VOL_NAME" -srcfolder build -ov -format UDZO
+
+echo "Created dist/$DMG_NAME"
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Install Ollama if missing
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "Downloading Ollama..."
+  curl -L https://ollama.ai/download/Ollama-darwin.zip -o /tmp/Ollama.zip
+  unzip -q /tmp/Ollama.zip -d /Applications
+fi
+
+# Start Ollama service
+open -a Ollama
+sleep 5
+
+# Pull Mixtral 8x7B model
+ollama pull mixtral:8x7b
+
+# Launch Web GUI
+GUI_PATH="$(dirname "$0")/webgui/index.html"
+open "$GUI_PATH"
+

--- a/webgui/index.html
+++ b/webgui/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Mixtral 8x7B WebGUI</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    #output { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Mixtral 8x7B WebGUI</h1>
+  <textarea id="prompt" rows="4" cols="60">Describe a cat sitting on a pile of money.</textarea><br />
+  <button id="send">Send</button>
+  <pre id="output"></pre>
+  <script>
+    async function sendPrompt(text) {
+      const response = await fetch('http://localhost:11434/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'mixtral:8x7b', prompt: text })
+      });
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let result = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        result += decoder.decode(value, { stream: true });
+        document.getElementById('output').textContent = result;
+      }
+    }
+    document.getElementById('send').onclick = () => {
+      sendPrompt(document.getElementById('prompt').value);
+    };
+    window.onload = () => {
+      sendPrompt(document.getElementById('prompt').value);
+    };
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add README instructions for DMG that installs Ollama and Mixtral 8x7B
- add build_dmg.sh to create DMG and install.sh for installing and launching web GUI
- add minimal web GUI that preloads a cat-and-money prompt
- document step-by-step DMG build and distribution workflow

## Testing
- `bash -n build_dmg.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5eaf3cee4832997f79434621f0914