### PR TITLE
Improve DMG build, installer, and web UI

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,23 @@
+name: Build DMG
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: chmod +x build_dmg.sh install.sh
+      - run: ./build_dmg.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: mixtral8x7b.dmg
+          path: dist/mixtral8x7b.dmg
+      - if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/mixtral8x7b.dmg

--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
 # Mixtral 8x7B macOS DMG
 
-This repository outlines a minimal DMG package for macOS that installs the
-[Ollama](https://ollama.ai) runtime, fetches the Mixtral 8x7B model, and launches a
-simple web interface. When opened, the page automatically sends an unrestricted
-prompt about a cat sitting on a pile of money and displays the model response.
+This repository outlines a minimal DMG package for macOS that installs the [Ollama](https://ollama.ai) runtime, fetches the Mixtral 8x7B model, and launches a simple web interface. When opened, the page automatically sends an unrestricted prompt about a cat sitting on a pile of money and displays the model response.
 
 ## Contents
 
-- `build_dmg.sh` &ndash; creates `mixtral8x7b.dmg` using `hdiutil`.
-- `install.sh` &ndash; runs from the DMG to install Ollama, pull the model and open the GUI.
-- `webgui/index.html` &ndash; browser client that talks to the local Ollama server.
+- `build_dmg.sh` – creates `mixtral8x7b.dmg` using `hdiutil`.
+- `install.sh` – copied as `install.command` in the DMG to install Ollama, pull the model and open the GUI.
+- `webgui/index.html` – browser client that talks to the local Ollama server.
+
+## Download
+
+Pre-built installers are available on the [releases page](https://github.com/your-org/mixtral8x7bmacos/releases). Download `mixtral8x7b.dmg` and follow the installation steps below.
 
 ## Building the DMG
 
-1. Clone this repository on a macOS machine and ensure the build script is
-   executable: `chmod +x build_dmg.sh install.sh` (already set in git but
-   included here for completeness).
-2. Run `./build_dmg.sh` to create the installer image. The script packages
-   `install.sh` and the `webgui` folder and outputs
-   `dist/mixtral8x7b.dmg`.
-3. (Optional) To share the DMG without macOS Gatekeeper warnings, sign and
-   notarize it with your Apple Developer ID using `codesign` and
-   `xcrun notarytool`.
+1. Clone this repository on a macOS machine and ensure the scripts are executable: `chmod +x build_dmg.sh install.sh` (already set in git but included here for completeness).
+2. Run `./build_dmg.sh` to create the installer image. The script copies `install.sh` as `install.command`, bundles `README.txt` and the `webgui` folder and outputs `dist/mixtral8x7b.dmg`.
+3. (Optional) To share the DMG without macOS Gatekeeper warnings, sign and notarize it with your Apple Developer ID using `codesign` and `xcrun notarytool`.
 4. Distribute the resulting `dist/mixtral8x7b.dmg` to end users.
 
 ## Installing and Running
 
-1. On another macOS machine, double-click the DMG to mount it. If Gatekeeper
-   warns about an unsigned script, right-click `install.sh` and choose **Open**.
-2. `install.sh` installs Ollama if needed, pulls the Mixtral 8x7B model and
-   starts the Ollama service.
-3. The default browser opens `webgui/index.html`, automatically issuing the
-   example “cat on a pile of money” prompt. You can edit the prompt and send
-   new requests from the page.
+1. On another macOS machine, double-click the DMG to mount it. If Gatekeeper warns about an unsigned script, right-click `install.command` and choose **Open**.
+2. `install.command` installs Ollama if needed, pulls the Mixtral 8x7B model and starts the Ollama service.
+3. The default browser opens `webgui/index.html`, automatically issuing the example “cat on a pile of money” prompt. You can edit the prompt and send new requests from the page.
 
-This setup avoids additional content restrictions; the model output is entirely
-controlled by your prompts.
+This setup avoids additional content restrictions; the model output is entirely controlled by your prompts.
+
+## System Requirements
+
+- macOS 13 or later
+- At least 20 GB of free disk space
+- Internet connection for downloading the Ollama runtime and model
+
+## Troubleshooting
+
+- **Script blocked by Gatekeeper:** right-click `install.command` and choose **Open**.
+- **Ollama service fails to start:** open the Ollama app manually and retry the installer.
+- **Model download issues:** ensure your internet connection is stable and sufficient disk space is available.
+
 

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,9 @@
+Mixtral 8x7B Installer
+----------------------
+
+1. Double-click `install.command` to install Ollama and download the Mixtral 8x7B model.
+2. Follow the prompts in the Terminal window.
+3. When complete, your browser will open the local web interface.
+
+If macOS blocks the script, right-click `install.command` and choose **Open**.
+

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -8,8 +8,13 @@ DMG_NAME="mixtral8x7b.dmg"
 rm -rf build dist
 mkdir -p "build/$APP_NAME" dist
 
-cp install.sh "build/$APP_NAME/"
+# Copy installer and assets
+cp install.sh "build/$APP_NAME/install.command"
+cp README.txt "build/$APP_NAME/README.txt"
 cp -r webgui "build/$APP_NAME/webgui"
+
+# Ensure installer has execute permissions
+chmod 755 "build/$APP_NAME/install.command"
 
 hdiutil create "dist/$DMG_NAME" -volname "$VOL_NAME" -srcfolder build -ov -format UDZO
 

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,48 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+error() {
+  echo "Error: $1" >&2
+  exit 1
+}
 
 # Install Ollama if missing
 if ! command -v ollama >/dev/null 2>&1; then
   echo "Downloading Ollama..."
-  curl -L https://ollama.ai/download/Ollama-darwin.zip -o /tmp/Ollama.zip
-  unzip -q /tmp/Ollama.zip -d /Applications
+  curl -L https://ollama.ai/download/Ollama-darwin.zip -o /tmp/Ollama.zip || error "Failed to download Ollama"
+  unzip -q /tmp/Ollama.zip -d /Applications || error "Failed to unzip Ollama"
+  rm -f /tmp/Ollama.zip
+  if ! command -v ollama >/dev/null 2>&1; then
+    error "Ollama installation failed"
+  fi
 fi
 
-# Start Ollama service
-open -a Ollama
-sleep 5
+# Start Ollama service and wait for it to become available
+echo "Starting Ollama service..."
+open -a Ollama || error "Unable to launch Ollama"
+timeout=60
+until curl -s http://localhost:11434/api/tags >/dev/null 2>&1; do
+  sleep 1
+  timeout=$((timeout-1))
+  if [ "$timeout" -le 0 ]; then
+    error "Ollama service did not start"
+  fi
+done
 
 # Pull Mixtral 8x7B model
-ollama pull mixtral:8x7b
+echo "Downloading Mixtral 8x7B model..."
+if ! ollama pull mixtral:8x7b; then
+  error "Model download failed"
+fi
+if ! ollama list 2>/dev/null | grep -q '^mixtral:8x7b'; then
+  error "Model not found after download"
+fi
 
 # Launch Web GUI
 GUI_PATH="$(dirname "$0")/webgui/index.html"
-open "$GUI_PATH"
+if [ -f "$GUI_PATH" ]; then
+  open "$GUI_PATH"
+else
+  echo "Web GUI not found at $GUI_PATH" >&2
+fi
 

--- a/webgui/index.html
+++ b/webgui/index.html
@@ -4,30 +4,61 @@
   <meta charset="utf-8" />
   <title>Mixtral 8x7B WebGUI</title>
   <style>
-    body { font-family: sans-serif; margin: 2em; }
-    #output { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+    body { font-family: sans-serif; margin: 2em; max-width: 800px; }
+    textarea { width: 100%; }
+    #output { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; min-height: 4em; }
+    #status { color: #666; margin-top: 0.5em; }
+    button[disabled] { opacity: 0.6; }
   </style>
 </head>
 <body>
   <h1>Mixtral 8x7B WebGUI</h1>
   <textarea id="prompt" rows="4" cols="60">Describe a cat sitting on a pile of money.</textarea><br />
   <button id="send">Send</button>
+  <div id="status"></div>
   <pre id="output"></pre>
   <script>
     async function sendPrompt(text) {
-      const response = await fetch('http://localhost:11434/api/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'mixtral:8x7b', prompt: text })
-      });
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let result = '';
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        result += decoder.decode(value, { stream: true });
-        document.getElementById('output').textContent = result;
+      const outputEl = document.getElementById('output');
+      const statusEl = document.getElementById('status');
+      const sendBtn = document.getElementById('send');
+      outputEl.textContent = '';
+      statusEl.textContent = 'Loading...';
+      sendBtn.disabled = true;
+      try {
+        const response = await fetch('http://localhost:11434/api/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: 'mixtral:8x7b', prompt: text })
+        });
+        if (!response.ok || !response.body) {
+          throw new Error('Request failed');
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let result = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split('\n').filter(Boolean);
+          for (const line of lines) {
+            try {
+              const json = JSON.parse(line);
+              if (json.response) {
+                result += json.response;
+                outputEl.textContent = result;
+              }
+            } catch (e) {
+              console.error('Failed to parse line', line, e);
+            }
+          }
+        }
+      } catch (err) {
+        outputEl.textContent = 'Error: ' + err.message;
+      } finally {
+        statusEl.textContent = '';
+        sendBtn.disabled = false;
       }
     }
     document.getElementById('send').onclick = () => {


### PR DESCRIPTION
## Summary
- package install.sh as install.command with README inside DMG
- add robust error handling for installing Ollama and model download
- enhance web interface with loading state, streaming output, and styling
- add GitHub Actions workflow to build and publish DMG
- document system requirements, download steps, and troubleshooting

## Testing
- `bash -n build_dmg.sh`
- `bash -n install.sh`
- `./build_dmg.sh` *(fails: hdiutil: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f21871ac83298b149a88d8ca73d2